### PR TITLE
Add ERC1271 contract signature verification unit tests

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,7 +5,8 @@
 	// List of extensions which should be recommended for users of this workspace.
 	"recommendations": [
 		"esbenp.prettier-vscode",
-		"juanblanco.solidity"
+		"juanblanco.solidity",
+		"dbaeumer.vscode-eslint"
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "JuanBlanco.solidity",
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": true
+    },
+    "eslint.validate": ["javascript"]
+}

--- a/contracts/test/MockSignatureVerifier.sol
+++ b/contracts/test/MockSignatureVerifier.sol
@@ -2,9 +2,9 @@
 
 pragma solidity ^0.8.10;
 
-import "@openzeppelin/contracts/interfaces/IERC1271.sol";
+import "@openzeppelin/contracts-upgradeable/interfaces/IERC1271Upgradeable.sol";
 
-contract MockSignatureVerifier is IERC1271 {
+contract MockSignatureVerifier is IERC1271Upgradeable {
     bool private mockIsValid = true;
 
     function isValidSignature(bytes32 hash, bytes memory signature)
@@ -13,7 +13,7 @@ contract MockSignatureVerifier is IERC1271 {
         returns (bytes4 magicValue)
     {
         if (mockIsValid) {
-            return IERC1271.isValidSignature.selector; // valid
+            return IERC1271Upgradeable.isValidSignature.selector; // valid
         }
         return "abcd"; // invalid
     }

--- a/test/Staking.test.ts
+++ b/test/Staking.test.ts
@@ -64,7 +64,7 @@ const initializeJuicenet = async ([deployer, a, b, noDeposit, withDeposit]: Wall
     users: { noJuice: a, noDeposit, withDeposit },
     tokens,
     oracles,
-    signatureVerifier
+    signatureVerifier,
   }
 }
 
@@ -971,7 +971,7 @@ describe("Staking", () => {
     })
 
     const getDummyContractPermission = async () => {
-      const deadline : number= await ethers.provider.getBlock("latest").then(b => b.timestamp + 10000)
+      const deadline : number = await ethers.provider.getBlock("latest").then(b => b.timestamp + 10000)
 
       let permission = {
         sender: signatureVerifier.address,
@@ -979,7 +979,7 @@ describe("Staking", () => {
         nonce: 0,
       }
 
-      let signature = "0xabab"; // dummy
+      let signature = "0xabab" // dummy
       let signedPermission = { data: permission, signature }
       return signedPermission
     }
@@ -987,16 +987,16 @@ describe("Staking", () => {
     it("contract signature checking succeeds", async () => {
       let amount = 100
       await stakingContract.mintJuice([signatureVerifier.address], [amount])
-      const sign = await getDummyContractPermission();
+      const sign = await getDummyContractPermission()
       await stakingContract.delegateDeposit(amount, sign)
       expect(await stakingContract.unstakedBalanceOf(signatureVerifier.address)).to.equal(amount)
     })
 
     it("contract signature checking fails", async () => {
       let amount = 100
-      await stakingContract.mintJuice([signatureVerifier.address], [amount])      
-      const sign = await getDummyContractPermission();
-      await signatureVerifier.setIsValidSignature(false);
+      await stakingContract.mintJuice([signatureVerifier.address], [amount])
+      const sign = await getDummyContractPermission()
+      await signatureVerifier.setIsValidSignature(false)
       await expect(stakingContract.delegateDeposit(amount, sign)).to.be.revertedWith("InvalidSignature()")
     })
   })


### PR DESCRIPTION
- ERC1271 testing: Add mock contract for verifying mock contract signatures. Only general logic is checked, the actual signature verification is anyway left open in the standard
- A few minor, supplementary unit tests for staking